### PR TITLE
Layout/issue 26

### DIFF
--- a/src/components/LoginDialog.vue
+++ b/src/components/LoginDialog.vue
@@ -203,20 +203,7 @@ const registerSubmit = async () => {
               >
             </p>
           </div>
-          <div>
-            <label for="email"></label>
-            <input
-              type="text"
-              placeholder="請輸入信箱"
-              id="email"
-              class="w-[80%] h-[48px] py-[12px] pr-[20px] pl-[16px] border-solid border border-[#EEEEEE] rounded-lg mt-1 mb-1 text-sm"
-              v-model="email"
-              v-on:keyup.enter="registerSubmit"
-            />
-          </div>
-          <!-- <p class=" text-red-500 text-sm font-light" v-show="isSubmitted&&email==''">
-            信箱不可為空
-          </p> -->
+
           <div class="relative">
             <label for="name"></label>
             <input
@@ -231,6 +218,21 @@ const registerSubmit = async () => {
           <!-- <p class=" text-red-500 text-sm font-light" v-show="isSubmitted&&name==''">
             帳號不可為空
           </p>         -->
+
+          <div>
+            <label for="email"></label>
+            <input
+              type="text"
+              placeholder="請輸入信箱"
+              id="email"
+              class="w-[80%] h-[48px] py-[12px] pr-[20px] pl-[16px] border-solid border border-[#EEEEEE] rounded-lg mt-1 mb-1 text-sm"
+              v-model="email"
+              v-on:keyup.enter="registerSubmit"
+            />
+          </div>
+          <!-- <p class=" text-red-500 text-sm font-light" v-show="isSubmitted&&email==''">
+            信箱不可為空
+          </p> -->
  
           <div class="relative">
             <label for="registerPassword"> </label>

--- a/src/components/LoginDialog.vue
+++ b/src/components/LoginDialog.vue
@@ -1,19 +1,118 @@
 <script setup>
-import { ref } from 'vue';
-import { XMarkIcon } from '@heroicons/vue/24/solid';
+import { ref } from 'vue'
+import { XMarkIcon } from '@heroicons/vue/24/solid'
+import { EyeIcon, EyeSlashIcon } from '@heroicons/vue/24/outline'
+import axios from 'axios'
+import {useUserStore} from '@/stores/userStore'
+import { LoginModalStore } from '@/stores/LoginModal.js'
+const LoginStore=LoginModalStore()
+const userStore=useUserStore()
 
-const showModal = ref(true);
+const showPassword = ref(false)
+function togglePasswordVisibility() {
+  showPassword.value = !showPassword.value
+}
+
+const switchLogRes = ref('login')
+
+//登入註冊資訊
+const identifier = ref('')
+const loginPassword = ref('')
+const name = ref('')
+const email = ref('')
+const registerPassword = ref('')
+
+
+const loginSubmit = async () => {
+  try {
+    const res = await axios.post(
+      'http://127.0.0.1:3000/users/login',
+      {
+        identifier: identifier.value,
+        password: loginPassword.value,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    )
+    if (res.data.status == 200) {
+      alert('登入成功')
+      identifier.value = ''
+      loginPassword.value = ''
+      userStore.setUser(res.data.user)
+      userStore.setToken(res.data.token)
+      LoginStore.closeModal()
+
+      console.log(res)
+    } else {
+      alert('登入失敗')
+    }
+  } catch (err) {
+    alert(err.response.data.message)
+  }
+}
+
+const hasAgreed = ref(false)
+const errorMessage = ref('')
+// const isSubmitted = ref(false);
+
+const registerSubmit = async () => {
+  // isSubmitted.value=true
+  if (!hasAgreed.value) {
+    errorMessage.value = '請閱讀並勾選使用條款'
+    return
+  }  errorMessage.value = ''  ;  
+    try {
+    const res = await axios.post(
+      'http://127.0.0.1:3000/users/register',
+      {
+        name: name.value,
+        email:email.value,
+        password: registerPassword.value,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    )
+    if (res.data.status == 201) {
+      alert('註冊成功')
+      name.value = ''
+      email.value=''
+      registerPassword.value = ''
+      switchLogRes.value = 'login';
+     
+    } else {
+      alert('登入失敗')
+    
+    }
+  } catch (err) {
+    alert(err.response.data.message)
+  }
+  }
+
 </script>
 
 <template>
-  <div v-if="showModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center overflow-auto">
-    <div class="bg-white pb-6 w-full h-full md:w-96 md:h-max md:rounded-2xl md:mb-20">
+  <div
+  
+    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center overflow-auto"
+  >
+    <div
+      class="bg-white pb-6 w-full h-full md:w-96 md:h-max md:rounded-2xl md:mb-20"
+    >
       <div class="relative">
         <button @click="$emit('close')" class="absolute right-2 top-2">
           <XMarkIcon class="w-6 h-6" />
         </button>
       </div>
-      <div class="flex justify-center items-center mt-8 sm:mt-8 md:mt-8 overflow-auto">
+
+      <div
+        class="flex justify-center items-center mt-8 sm:mt-8 md:mt-8 overflow-auto"
+      >
         <div class="text-center">
           <div class="mb-4">
             <img
@@ -22,62 +121,190 @@ const showModal = ref(true);
               class="h-12 w-auto mx-auto"
             />
           </div>
-          <h2 class="text-xl font-bold">歡迎使用旅圖</h2>
-          <p class="text-sm mt-2">暢你的旅遊 照你的玩</p>
         </div>
       </div>
-           
+
+      <div class="flex justify-center items-center">
+        <div class="text-center w-full" v-if="switchLogRes === 'login'">
+          <h2 class="text-xl font-bold">會員登入</h2>
+          <div class="flex justify-center">
+            <p class="text-sm pt-2 pb-[20px]">
+              還不是會員?
+              <input
+                type="radio"
+                id="register"
+                value="register"
+                class="hidden"
+                v-model="switchLogRes"
+              />
+              <label
+                for="register"
+                class="cursor-pointer text-blue-500 underline underline-offset-1 decoration-blue-500 text-sm"
+                >快速註冊</label
+              >
+            </p>
+          </div>
+          <div>
+            <label for="identifier"></label>
+            <input
+              type="text"
+              placeholder="請輸入帳號/信箱/手機號碼"
+              id="identifier"
+              class="w-[80%] h-[48px] py-[12px] pr-[20px] pl-[16px] border-solid border border-[#EEEEEE] rounded-lg mt-1 mb-1 text-sm"
+              v-model="identifier"
+              v-on:keyup.enter="loginSubmit"
+            />
+          </div>
+          <div class="relative">
+            <label for="loginPassword"> </label>
+            <input
+              :type="!showPassword ? 'password' : 'text'"
+              placeholder="請輸入密碼"
+              id="loginPassword"
+              class="w-[80%] h-[48px] py-[12px] pr-[20px] pl-[16px] border-solid border border-[#EEEEEE] rounded-lg mt-1 mb-1 text-sm"
+              v-model="loginPassword"
+              autocomplete="new-password"
+              v-on:keyup.enter="loginSubmit"
+            />
+            <button
+              class="absolute top-1/2 right-[50px] transform -translate-y-1/2 text-gray-400"
+              @click="togglePasswordVisibility"
+            >
+              <EyeIcon v-if="showPassword" class="w-5 h-5" />
+              <EyeSlashIcon v-else class="w-5 h-5" />
+            </button>
+          </div>
+          <button
+            @click="loginSubmit"
+            class="w-[80%] bg-primary-600 text-white py-3 rounded-full font-medium hover:bg-primary-700 mt-10"
+          >
+            會員登入
+          </button>
+        </div>
+      </div>
+
+      <div class="flex justify-center items-center">
+        <div class="text-center w-full" v-if="switchLogRes === 'register'">
+          <h2 class="text-xl font-bold">會員註冊</h2>
+          <div >
+            <p class="text-sm pt-2 pb-[20px]">
+              已經註冊完成?
+              <input
+                type="radio"
+                id="login"
+                value="login"
+                class="hidden"
+                v-model="switchLogRes"
+              />
+              <label
+                for="login"
+                class="cursor-pointer text-blue-500 underline underline-offset-1 decoration-blue-500 text-sm"
+                >快速登入</label
+              >
+            </p>
+          </div>
+          <div>
+            <label for="email"></label>
+            <input
+              type="text"
+              placeholder="請輸入信箱"
+              id="email"
+              class="w-[80%] h-[48px] py-[12px] pr-[20px] pl-[16px] border-solid border border-[#EEEEEE] rounded-lg mt-1 mb-1 text-sm"
+              v-model="email"
+              v-on:keyup.enter="registerSubmit"
+            />
+          </div>
+          <!-- <p class=" text-red-500 text-sm font-light" v-show="isSubmitted&&email==''">
+            信箱不可為空
+          </p> -->
+          <div class="relative">
+            <label for="name"></label>
+            <input
+              type="text"
+              placeholder="請輸入帳號/暱稱"
+              id="name"
+              class="w-[80%] h-[48px] py-[12px] pr-[20px] pl-[16px] border-solid border border-[#EEEEEE] rounded-lg mt-1 mb-1 text-sm"
+              v-model="name"
+              v-on:keyup.enter="registerSubmit"
+            />
+          </div>
+          <!-- <p class=" text-red-500 text-sm font-light" v-show="isSubmitted&&name==''">
+            帳號不可為空
+          </p>         -->
+ 
+          <div class="relative">
+            <label for="registerPassword"> </label>
+            <input
+              :type="!showPassword ? 'password' : 'text'"
+              placeholder="請輸入密碼"
+              id="registerPassword"
+              class="w-[80%] h-[48px] py-[12px] pr-[20px] pl-[16px] border-solid border border-[#EEEEEE] rounded-lg mt-1 mb-1 text-sm"
+              v-model="registerPassword"
+              autocomplete="new-password"
+              v-on:keyup.enter="registerSubmit"
+            />
+            <button
+              class="absolute top-1/2 right-[50px] transform -translate-y-1/2 text-gray-400"
+              @click="togglePasswordVisibility"
+            >
+              <EyeIcon v-if="showPassword" class="w-5 h-5" />
+              <EyeSlashIcon v-else class="w-5 h-5" />
+            </button>
+          </div>       
+          <!-- <p class="text-red-500 text-sm font-light" v-show="isSubmitted&&registerPassword==''">
+            密碼不可為空
+          </p> -->
 
 
-
-
-      <div class="flex justify-center items-center mt-20">
-        <div class="text-center">
-          <div class="flex items-center justify-center mb-4">
+          <div class="flex items-center justify-center mt-10">
             <input
               type="checkbox"
               id="agreement"
               class="mt-1 h-4 w-4 text-blue-600 focus:ring-blue-500"
+              v-model="hasAgreed"
             />
             <label for="agreement" class="ml-2 text-sm">
-              我已閱讀並同意 <a href="#" class="text-blue-500 underline">旅圖會員服務條款</a>
+              我已閱讀並同意
+              <a href="#" class="text-blue-500 underline">旅圖會員服務條款</a>
             </label>
           </div>
+          <p class="text-red-500 text-sm font-light" v-if="errorMessage">
+            {{ errorMessage }}
+          </p>
+
           <button
-            class="w-full bg-primary-600 text-white py-3 rounded-full font-medium hover:bg-primary-700"
+            @click="registerSubmit"
+            class="w-[80%] bg-primary-600 text-white py-3 rounded-full font-medium hover:bg-primary-700 mt-4"
           >
-            旅圖會員登入/註冊
+            會員註冊
           </button>
         </div>
       </div>
 
       <div class="flex justify-center items-center gap-6 mt-5">
-        <button class="h-8 w-8 rounded-full shadow flex justify-center items-center">
+        <a
+          p.href="http://localhost:3000/auth/google/callback"
+          class="h-8 w-8 rounded-full shadow flex justify-center items-center cursor-pointer"
+        >
           <img
-            src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQSC8fFURU-S1FRIkYCVhF6LbBB0BQUbGd6bQ&s"
+            src="https://t4.ftcdn.net/jpg/03/91/79/25/360_F_391792593_BYfEk8FhvfNvXC5ERCw166qRFb8mYWya.jpg"
             alt="Google"
             class="h-5 w-5"
           />
-        </button>
-        <button class="h-8 w-8 rounded-full shadow flex justify-center items-center">
+        </a>
+        <a
+          p.href="http://localhost:3000/api/auth/line/callback"
+          class="h-8 w-8 rounded-full shadow flex justify-center items-center"
+        >
           <img
-            src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQSC8fFURU-S1FRIkYCVhF6LbBB0BQUbGd6bQ&s"
+            src="https://e7.pngegg.com/pngimages/630/685/png-clipart-line-computer-icons-social-media-line-flat-text-rectangle-thumbnail.png"
             alt="LINE"
             class="h-5 w-5"
           />
-        </button>
-        <button class="h-8 w-8 rounded-full shadow flex justify-center items-center">
-          <img
-            src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQSC8fFURU-S1FRIkYCVhF6LbBB0BQUbGd6bQ&s"
-            alt="Apple"
-            class="h-5 w-5"
-          />
-        </button>
+        </a>
       </div>
     </div>
   </div>
 </template>
 
-<style scoped>
-
-</style>
+<style scoped></style>

--- a/src/components/LoginDialog.vue
+++ b/src/components/LoginDialog.vue
@@ -26,6 +26,10 @@ const showModal = ref(true);
           <p class="text-sm mt-2">暢你的旅遊 照你的玩</p>
         </div>
       </div>
+           
+
+
+
 
       <div class="flex justify-center items-center mt-20">
         <div class="text-center">

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -7,6 +7,9 @@ import {
   UserCircleIcon,
   Bars3Icon,
 } from '@heroicons/vue/24/solid';
+import { LoginModalStore } from '@/stores/LoginModal.js'
+const LoginStore = LoginModalStore()
+
 
 const isMenuOpen = ref(false);
 const toggleMenu = () => {
@@ -79,7 +82,7 @@ const closeLoginDialog = () => {
       </li>
       <hr class="border-t border-gray my-4 w-full" />
       <li class="flex items-center p-2 hover:bg-primary-100  rounded-lg transition-all">
-        <button class="flex w-full" @click="openLoginDialog">
+        <button class="flex w-full" @click="LoginStore.openModal()">
           <UserCircleIcon class="w-6 h-6 flex-none text-slate-500" />
           <span
             class="ml-3 font-medium opacity-0 group-hover:opacity-100 hidden group-hover:inline-block transition-opacity duration-500 delay-500 whitespace-nowrap text-slate-500 hover:text-primary-800"
@@ -90,7 +93,8 @@ const closeLoginDialog = () => {
       </li>
     </ul>
   </div>
-  <LoginDialog class="z-20" v-if="isLoginDialogOpen" @close="closeLoginDialog" />
+  <!-- <LoginDialog class="z-20" v-if="isLoginDialogOpen" @close="closeLoginDialog" /> -->
+  <LoginDialog class="z-20" v-if="LoginStore.isOpen" @close="LoginStore.closeModal" />
   <div>
   </div>
 </template>

--- a/src/stores/LoginModal.js
+++ b/src/stores/LoginModal.js
@@ -1,0 +1,20 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const LoginModalStore = defineStore('LoginDialog', () => {
+  const isOpen = ref(false)
+
+  const openModal = () => {
+    isOpen.value = true
+  }
+
+  const closeModal = () => {
+    isOpen.value = false
+  }
+
+  const toggleModal = () => {
+    isOpen.value = !isOpen.value
+  }
+
+  return { isOpen, openModal, closeModal, toggleModal }
+})

--- a/src/stores/userStore.js
+++ b/src/stores/userStore.js
@@ -1,0 +1,16 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+const useUserStore = defineStore('user', () => {
+  const user = ref('')
+  const token = ref('')
+  const setUser = (userData) => {
+    user.value = userData
+  }
+  const setToken = (tokenData) => {
+    token.value = tokenData
+  }
+  return { user, token, setUser, setToken }
+})
+
+export { useUserStore }

--- a/src/views/MemberView.vue
+++ b/src/views/MemberView.vue
@@ -11,6 +11,8 @@ import {  HeartIcon,
           XMarkIcon,
           PencilSquareIcon,
 } from '@heroicons/vue/24/solid';
+import { LoginModalStore } from '@/stores/LoginModal.js';
+const LoginStore=LoginModalStore()
 const closeEditmodal = () => {
   const dialog = document.getElementById("Editmodal"); 
   dialog?.close();
@@ -213,7 +215,7 @@ const closePersonalInformatioMmodal = () => {
               <p class="text-sm font-bold">旅圖會員登入/註冊</p>
               <p class="text-xs">成為會員，即享會員專屬功能！</p>
             </div>
-            <button class="bg-secondary-500 p-2 rounded-full">
+            <button class="bg-secondary-500 p-2 rounded-full" @click="LoginStore.openModal">
               <p class="text-white text-xs">立即加入</p>
             </button>
           </div>


### PR DESCRIPTION
登入、註冊功能&切版
===
**主要功能:串接後端api、處理錯誤訊息、在登入時存取使用者資訊以及token方便在其他頁面辨認使用者身分。**

彈窗:
把modal彈出邏輯獨立到pinia方便在其他頁面訪問(綁定多個按鈕)

註冊畫面:
![image](https://github.com/user-attachments/assets/46b476f7-dca3-4561-b354-a14771ed54e9)
勾選使用者條款後才可送出:
![image](https://github.com/user-attachments/assets/ad5fd898-653f-4cb4-a39d-aa78d1f7e262)
未依照指定格式填寫會顯示錯誤訊息:
![image](https://github.com/user-attachments/assets/7c02db29-0239-47a2-aa6a-f2b988a7dada)
![image](https://github.com/user-attachments/assets/4c742a21-d243-4954-a22c-0859a5db4b75)
![image](https://github.com/user-attachments/assets/44c22f69-1cca-455e-8934-12eed050ab7d)

註冊成功後自動跳轉到登入頁面:
![image](https://github.com/user-attachments/assets/baf31138-c7b5-4203-94f7-7c3410f218dc)

登入畫面:
輸入username、email、phone皆可登入(擇一)
![image](https://github.com/user-attachments/assets/dc13139b-3722-421a-b0f6-4eaa0c0f376d)
錯誤訊息:
![image](https://github.com/user-attachments/assets/3835f840-6612-4793-a139-3ad0abc89127)
![image](https://github.com/user-attachments/assets/607d8c8f-e1fa-4146-ae1d-086527f8d3db)

透過點擊icon切換顯示/不顯示密碼:
![image](https://github.com/user-attachments/assets/ff015e9a-4b85-4ae3-8094-4b5d1739be7d)
![image](https://github.com/user-attachments/assets/106072c7-2228-4cbc-b35a-a4ad262de10b)

登入成功:
自動關閉視窗
![image](https://github.com/user-attachments/assets/490d2af7-e39f-4384-970a-399a41d6cac8)
登入後於pinia儲存user資料&token:
![image](https://github.com/user-attachments/assets/ad33bcf0-ead1-480b-9dc6-539a83a297b1)





