### PR TITLE
更新分享、共編 modal 的狀態更新方式

### DIFF
--- a/src/components/SchedulesList.vue
+++ b/src/components/SchedulesList.vue
@@ -68,6 +68,10 @@ const openShareModal = () => {
 const openInviteModal = () => {
   activeStatus.value = 'invite'
 }
+const updateStatus = (status) => {
+  activeStatus.value = status
+}
+
 const login = () => {
   LoginStore.openModal()
   listToggle()
@@ -367,7 +371,10 @@ onMounted(async () => {
       </div>
     </div>
 
-    <ShareScheduleModal :activeTab="activeStatus" />
+    <ShareScheduleModal
+      :activeTab="activeStatus"
+      @updateStatus="updateStatus"
+    />
     <DeleteScheduleModal :toBeDeleteId="deletedId" :updateList="getSchedules" />
     <NewScheduleModal :savetoSchedules="getSchedules" />
   </div>

--- a/src/components/ShareScheduleModal.vue
+++ b/src/components/ShareScheduleModal.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, defineProps } from 'vue'
+import { ref, defineProps, defineEmits } from 'vue'
 import { LinkIcon, ShareIcon, ChevronDownIcon } from '@heroicons/vue/24/outline'
 import ScheduleSummaryModal from './ScheduleSummaryModal.vue'
 import ExportScheduleModal from './ExportScheduleModal.vue'
@@ -12,6 +12,10 @@ const props = defineProps({
     required: true,
   },
 })
+const emit = defineEmits(['updateStatus'])
+const updateActiveTab = (status) => {
+  emit('updateStatus', status)
+}
 </script>
 
 <template>
@@ -33,8 +37,8 @@ const props = defineProps({
           id="share"
           type="radio"
           name="tab"
-          v-model="props.activeTab"
-          value="share"
+          :checked="activeTab === 'share'"
+          @change="updateActiveTab('share')"
           class="hidden"
         />
         <label
@@ -46,8 +50,8 @@ const props = defineProps({
           id="invite"
           type="radio"
           name="tab"
-          v-model="props.activeTab"
-          value="invite"
+          :checked="activeTab === 'invite'"
+          @change="updateActiveTab('invite')"
           class="hidden"
         />
         <label


### PR DESCRIPTION
發現之前的調整讓分享行程的彈窗開啟後，無法正常切換 tab 來查看對應的內容，此版已修復。
![image](https://github.com/user-attachments/assets/fda2491d-5f09-4885-a358-0f346792bfad)
