### PR TITLE
feat: 新增行程總覽「編輯行程」、「行程筆記」功能

### DIFF
--- a/src/components/ScheduleDetail.vue
+++ b/src/components/ScheduleDetail.vue
@@ -1,30 +1,62 @@
 <script setup>
-import { ref, inject } from 'vue'
-import { XMarkIcon, ChevronLeftIcon, ArrowUpTrayIcon, UsersIcon, PencilIcon, TrashIcon, MagnifyingGlassIcon, BookmarkIcon, CalendarIcon, DocumentDuplicateIcon, PlusCircleIcon } from '@heroicons/vue/24/outline'
-import { EllipsisHorizontalIcon, MapPinIcon } from '@heroicons/vue/24/solid'
-import ShareScheduleModal from './ShareScheduleModal.vue'
-import EditPlaceModal from './EditPlaceModal.vue'
-import DeletePerDayModal from './DeletePerDayModal.vue'
-import MoveToOtherDateModal from './MoveToOtherDateModal.vue'
-import DeletePerPlaceModal from './DeletePerPlaceModal.vue'
-import draggable from 'vuedraggable'
+import { ref, inject } from "vue"
+import {
+  XMarkIcon,
+  ChevronLeftIcon,
+  ArrowUpTrayIcon,
+  PencilIcon,
+  TrashIcon,
+  MagnifyingGlassIcon,
+  BookmarkIcon,
+  CalendarIcon,
+  DocumentDuplicateIcon,
+  PlusCircleIcon,
+} from "@heroicons/vue/24/outline"
+import { EllipsisHorizontalIcon, MapPinIcon } from "@heroicons/vue/24/solid"
+import EditPlaceModal from "./EditPlaceModal.vue"
+import DeletePerDayModal from "./DeletePerDayModal.vue"
+import MoveToOtherDateModal from "./MoveToOtherDateModal.vue"
+import DeletePerPlaceModal from "./DeletePerPlaceModal.vue"
+import ScheduleOverview from "./ScheduleOverview.vue"
+import draggable from "vuedraggable"
 
-const listAndDetailToggle = inject('listAndDetailToggle')
-const detailToggle = inject('detailToggle')
-const transportationToggle = inject('transportationToggle')
+const listAndDetailToggle = inject("listAndDetailToggle")
+const detailToggle = inject("detailToggle")
+const transportationToggle = inject("transportationToggle")
 
-      // 定義響應式陣列
-      const place = ref([
-    { id: 1, name: '香港迪士尼樂園', time: '08:00', stayhour: 1,imgUrl:"https://lh3.googleusercontent.com/places/ANJU3Ds3MXRcZf77xt6ejMr5CyGxuySKPa3n9yUWJ5EqShizmd3EPHhQNT8_xFYRuOpksBffhO-lOh21FWclCl_ZQv94ZzST19IrWtM=s1600-w480",transhour:0},
-    { id: 2, name: '香港杜莎夫人蠟像館', time: '09:00', stayhour: 1,imgUrl:"https://chictirpstorageprod.blob.core.windows.net/poi/8d8b0e7e-b654-4e7f-91b8-096097b84246.jpg", transhour: 0},
-    { id: 3, name: '天際 100', time: '10:00', stayhour: 1 ,imgUrl:"https://lh3.googleusercontent.com/places/ANJU3DsUY2LM1fuJKUAmH-PF1rJfdcdHY1r2gLmSddnr24aqnSDDkNAG5oMI5BNaQ1xXBbtxiJTyTnixNTKAyl541gqVjZax6o9DbsM=s1600-w480",transhour:0},
-  ])
+// 定義響應式陣列
+const place = ref([
+  {
+    id: 1,
+    name: "香港迪士尼樂園",
+    time: "08:00",
+    stayhour: 1,
+    imgUrl:
+      "https://lh3.googleusercontent.com/places/ANJU3Ds3MXRcZf77xt6ejMr5CyGxuySKPa3n9yUWJ5EqShizmd3EPHhQNT8_xFYRuOpksBffhO-lOh21FWclCl_ZQv94ZzST19IrWtM=s1600-w480",
+    transhour: 0,
+  },
+  {
+    id: 2,
+    name: "香港杜莎夫人蠟像館",
+    time: "09:00",
+    stayhour: 1,
+    imgUrl:
+      "https://chictirpstorageprod.blob.core.windows.net/poi/8d8b0e7e-b654-4e7f-91b8-096097b84246.jpg",
+    transhour: 0,
+  },
+  {
+    id: 3,
+    name: "天際 100",
+    time: "10:00",
+    stayhour: 1,
+    imgUrl:
+      "https://lh3.googleusercontent.com/places/ANJU3DsUY2LM1fuJKUAmH-PF1rJfdcdHY1r2gLmSddnr24aqnSDDkNAG5oMI5BNaQ1xXBbtxiJTyTnixNTKAyl541gqVjZax6o9DbsM=s1600-w480",
+    transhour: 0,
+  },
+])
 
-  //交通時間送出請求
-
-  // 拖曳狀態
-  const drag = ref(false)
-
+// 拖曳狀態
+const drag = ref(false)
 </script>
 
 <template>
@@ -32,14 +64,28 @@ const transportationToggle = inject('transportationToggle')
     <!-- header -->
     <div class="bg-primary-600 py-5 ps-4 pe-14 relative">
       <div class="flex items-center justify-between gap-0.5">
-        <div class="flex items-center hover:cursor-pointer" @click="detailToggle">
-          <span class="inline-block w-4 h-4 text-white"><ChevronLeftIcon /></span>
+        <div
+          class="flex items-center hover:cursor-pointer"
+          @click="detailToggle"
+        >
+          <span class="inline-block w-4 h-4 text-white"
+            ><ChevronLeftIcon
+          /></span>
           <h2 class="text-white text-sm">行程列表</h2>
         </div>
-        <div class="w-5 h-5 text-white hover:cursor-pointer" onclick="shareScheduleModal.showModal()"><ArrowUpTrayIcon /></div>
-        <ShareScheduleModal />
+        <div
+          class="w-5 h-5 text-white hover:cursor-pointer"
+          onclick="shareSchedule.showModal()"
+        >
+          <ArrowUpTrayIcon />
+        </div>
+        <!-- <ShareScheduleModal /> -->
       </div>
-      <label class="bg-gray opacity-80 text-gray-600 w-8 h-8 rounded-full absolute top-3.5 right-4 p-1.5 hover:opacity-90 tooltip tooltip-bottom hover:cursor-pointer" data-tip="隱藏行程" @click="listAndDetailToggle">
+      <label
+        class="bg-gray opacity-80 text-gray-600 w-8 h-8 rounded-full absolute top-3.5 right-4 p-1.5 hover:opacity-90 tooltip tooltip-bottom hover:cursor-pointer"
+        data-tip="隱藏行程"
+        @click="listAndDetailToggle"
+      >
         <XMarkIcon />
       </label>
     </div>
@@ -47,89 +93,87 @@ const transportationToggle = inject('transportationToggle')
     <div class="flex border-b border-gray">
       <div class="w-full h-12 flex pt-2 ps-8 pe-3 overflow-x-scroll">
         <ul class="flex gap-4">
-          <li class="whitespace-nowrap"><a href="" class="pb-2 text-gray-800 font-medium text-sm border-b-2 border-primary-600">總覽頁</a></li>
-          <li class="whitespace-nowrap"><a href="" class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600">第1天</a></li>
-          <li class="whitespace-nowrap"><a href="" class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600">第2天</a></li>
-          <li class="whitespace-nowrap"><a href="" class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600">第3天</a></li>
-          <li class="whitespace-nowrap"><a href="" class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600">第4天</a></li>
-          <li class="whitespace-nowrap"><a href="" class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600">第5天</a></li>
-          <li class="whitespace-nowrap"><a href="" class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600">第6天</a></li>
-          <li class="whitespace-nowrap"><a href="" class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600">第7天</a></li>
+          <li class="whitespace-nowrap">
+            <a
+              href=""
+              class="pb-2 text-gray-800 font-medium text-sm border-b-2 border-primary-600"
+              >總覽頁</a
+            >
+          </li>
+          <li class="whitespace-nowrap">
+            <a
+              href=""
+              class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600"
+              >第1天</a
+            >
+          </li>
+          <li class="whitespace-nowrap">
+            <a
+              href=""
+              class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600"
+              >第2天</a
+            >
+          </li>
+          <li class="whitespace-nowrap">
+            <a
+              href=""
+              class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600"
+              >第3天</a
+            >
+          </li>
+          <li class="whitespace-nowrap">
+            <a
+              href=""
+              class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600"
+              >第4天</a
+            >
+          </li>
+          <li class="whitespace-nowrap">
+            <a
+              href=""
+              class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600"
+              >第5天</a
+            >
+          </li>
+          <li class="whitespace-nowrap">
+            <a
+              href=""
+              class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600"
+              >第6天</a
+            >
+          </li>
+          <li class="whitespace-nowrap">
+            <a
+              href=""
+              class="pb-2 text-gray-500 font-medium text-sm hover:text-gray-800 hover:border-b-2 hover:border-primary-600"
+              >第7天</a
+            >
+          </li>
         </ul>
       </div>
       <div class="w-12 pt-2 text-primary-600 hover:cursor-pointer text-center">
-        <span class="inline-block w-7 h-7 rounded-full hover:bg-gray"><PlusCircleIcon /></span>
+        <span class="inline-block w-7 h-7 rounded-full hover:bg-gray"
+          ><PlusCircleIcon
+        /></span>
       </div>
     </div>
-    <!-- overview -->
-    <div class="hidden">
-      <!-- schedule title -->
-      <div class="w-full pt-5 px-6 pb-8">
-        <div class="flex items-center gap-2">
-          <p class="text-xl font-medium mb-2">香港</p>
-          <span class="inline-block w-4 h-4 mb-2 hover:cursor-pointer"><PencilIcon /></span>
-        </div>
-        <p class="text-sm mb-3">2024/11/15 - 2024/11/29</p>
-        <p class="text-sm text-gray-500 border-l border-gray-400 ps-3" onclick="schedul_note.showModal()">還沒有寫筆記哦...
-          <span class="text-primary-600 font-medium">編輯筆記</span>
-        </p> 
-        <!-- schedule note -->
-        <dialog id="schedul_note" class="modal">
-          <div class="modal-box w-screen md:w-[480px]">
-            <form method="dialog">
-              <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-            </form>
-            <h2 class="text-2xl font-medium text-center pt-6 mb-4">行程筆記</h2>
-            <textarea class="w-full h-[500px] textarea textarea-lg focus:border-0 focus:outline-none" placeholder="記下重要的旅行細節吧"></textarea>
-            <div class="w-full flex gap-3 h-20 px-6 py-4 bg-white border-t border-gray fixed bottom-0 right-0">
-              <button class="w-full h-12 px-5 py-3 border border-primary-600 text-primary-600 text-center rounded-3xl font-medium hover:bg-primary-100">
-                取消
-              </button>
-              <button class="w-full h-12 px-5 py-3 bg-primary-600 hover:bg-primary-700 text-white text-center rounded-3xl font-medium">
-                儲存
-              </button>
-            </div>
-          </div>
-          <form method="dialog" class="modal-backdrop">
-            <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-            <button>close</button>
-          </form>
-        </dialog> 
-      </div> 
-      <!-- my tool -->
-      <div class="p-5">
-        <div class="flex items-center gap-1 mb-3">
-          <span class="inline-block w-5 h-5"><UsersIcon/></span>
-          <p>我的工具</p>
-        </div>
-        <ul class="flex justify-between">
-          <li class="w-[100px] pt-4 px-2.5 pb-2.5 bg-gray rounded-xl hover:cursor-pointer hover:bg-primary-100 hover:text-primary-600">
-            <img src="https://web.chictrip.com.tw/assets/img-myfavorite.42ac10ec.svg" class="mx-auto" alt="">
-            <p class="text-center font-medium mt-2">收藏</p>
-          </li>
-          <li class="w-[100px] pt-4 px-2.5 pb-2.5 bg-gray rounded-xl hover:cursor-pointer hover:bg-primary-100 hover:text-primary-600">
-            <img src="https://web.chictrip.com.tw/assets/img-share.7c89cdf8.svg" class="mx-auto" alt="">
-            <p class="text-center font-medium mt-2">共編</p>
-          </li>
-          <li class="w-[100px] pt-4 px-2.5 pb-2.5 bg-gray rounded-xl hover:cursor-pointer hover:bg-primary-100 hover:text-primary-600">
-            <img src="https://web.chictrip.com.tw/assets/img-exportbook.a62ae1d0.svg" class="mx-auto" alt="">
-            <p class="text-center font-medium mt-2">分帳</p>
-          </li>
-        </ul>
-      </div>
-    </div>
+    <ScheduleOverview />
     <!-- everyday schedule -->
-    <div class="">
+    <div class="hidden">
       <!-- date -->
-      <div class="pt-5 px-5 mb-3 ">
+      <div class="pt-5 px-5 mb-3">
         <div class="date w-28 flex gap-1 cursor-pointer">
           <p class="font-medium">11/15 週五</p>
           <div class="dropdown lg:hidden">
             <div class="w-6 h-6" tabindex="0" role="button">
-              <EllipsisHorizontalIcon/>
+              <EllipsisHorizontalIcon />
             </div>
             <!-- delete dropdown -->
-            <div tabindex="0" class=" dropdown-content flex gap-2 bg-base-100 rounded z-[1] w-32 p-2 shadow hover:bg-gray" onclick="delete_date.showModal()">
+            <div
+              tabindex="0"
+              class="dropdown-content flex gap-2 bg-base-100 rounded z-[1] w-32 p-2 shadow hover:bg-gray"
+              onclick="delete_date.showModal()"
+            >
               <span class="w-6 h-6"><TrashIcon /></span>
               <p>刪除這天</p>
               <DeletePerDayModal />
@@ -137,119 +181,194 @@ const transportationToggle = inject('transportationToggle')
           </div>
         </div>
       </div>
-    </div>
       <!-- place & transportation -->
-      <draggable 
-        v-model="place" 
+      <draggable
+        v-model="place"
         :animation="250"
-        group="local" 
-        @start="drag=true" 
-        @end="drag=false"
+        group="local"
+        @start="drag = true"
+        @end="drag = false"
         item-key="id"
       >
         <template #item="{ element }">
           <div class="place-transportation container">
-          <div class="pt-2 px-5 pb-1 overflow-y-hidden  overflow-x-hidden bg-white">
-          <div :key="element.id" class="place w-full bg-gray rounded-xl border border-gray mt-4">
-            <div class="flex p-1">
-              <img class="w-[108px] h-[108px] rounded-xl object-cover" :src="element.imgUrl">
-              <div class="w-cal flex justify-between">
-                <ul class="px-4 flex flex-col gap-0.5 justify-center">
-                  <li class="text-sm font-medium text-orange-400">{{ element.time }}</li>
-                  <li class="font-medium">{{ element.name }}</li>
-                  <li class="text-xs text-gray-400">{{ `停留 ${element.stayhour} 時` }}</li>
-                </ul>
-                <div class="dropdown p-1">
-                  <button role="button" class="w-5 h-5 rounded-full bg-gray-300 hover:bg-gray-400 text-white relative">
-                    <EllipsisHorizontalIcon />
-                  </button>
-                  <!-- dropdown 控制開關 -->
-                  <ul tabindex="0" class="dropdown-content w-32 bg-white rounded border absolute right-[-12px] top-8 shadow-xl">
-                    <li @click="moveDate.showModal()">
-                      <a class="flex items-center gap-1 text-sm px-5 py-2 hover:bg-gray" href="#">
-                        <span class="inline-block w-6 h-6"><CalendarIcon/></span>
-                        <p>移到別天</p>
-                      </a>  
-                    </li>
-                    <MoveToOtherDateModal />
-                    <li>
-                      <a class="flex items-center gap-1 text-sm px-5 py-2 hover:bg-gray" href="#">
-                        <span class="inline-block w-6 h-6"><DocumentDuplicateIcon/></span>
-                        <p>複製</p>
-                      </a>  
-                    </li>
-                    <li class="border-t" @click="delete_place.showModal()">
-                      <a class="flex items-center gap-1 text-sm px-5 py-2 hover:bg-gray" href="#">
-                        <span class="inline-block w-6 h-6"><TrashIcon/></span>
-                        <p>刪除</p>
-                      </a>  
-                    </li>
-                    <DeletePerPlaceModal />
-                  </ul>
+            <div
+              class="pt-2 px-5 pb-1 overflow-y-hidden overflow-x-hidden bg-white"
+            >
+              <div
+                :key="element.id"
+                class="place w-full bg-gray rounded-xl border border-gray mt-4"
+              >
+                <div class="flex p-1">
+                  <img
+                    class="w-[108px] h-[108px] rounded-xl object-cover"
+                    :src="element.imgUrl"
+                  />
+                  <div class="w-cal flex justify-between">
+                    <ul class="px-4 flex flex-col gap-0.5 justify-center">
+                      <li class="text-sm font-medium text-orange-400">
+                        {{ element.time }}
+                      </li>
+                      <li class="font-medium">{{ element.name }}</li>
+                      <li class="text-xs text-gray-400">
+                        {{ `停留 ${element.stayhour} 時` }}
+                      </li>
+                    </ul>
+                    <div class="dropdown p-1">
+                      <button
+                        role="button"
+                        class="w-5 h-5 rounded-full bg-gray-300 hover:bg-gray-400 text-white relative"
+                      >
+                        <EllipsisHorizontalIcon />
+                      </button>
+                      <!-- dropdown 控制開關 -->
+                      <ul
+                        tabindex="0"
+                        class="dropdown-content w-32 bg-white rounded border absolute right-[-12px] top-8 shadow-xl"
+                      >
+                        <li @click="moveDate.showModal()">
+                          <a
+                            class="flex items-center gap-1 text-sm px-5 py-2 hover:bg-gray"
+                            href="#"
+                          >
+                            <span class="inline-block w-6 h-6"
+                              ><CalendarIcon
+                            /></span>
+                            <p>移到別天</p>
+                          </a>
+                        </li>
+                        <MoveToOtherDateModal />
+                        <li>
+                          <a
+                            class="flex items-center gap-1 text-sm px-5 py-2 hover:bg-gray"
+                            href="#"
+                          >
+                            <span class="inline-block w-6 h-6"
+                              ><DocumentDuplicateIcon
+                            /></span>
+                            <p>複製</p>
+                          </a>
+                        </li>
+                        <li class="border-t" @click="delete_place.showModal()">
+                          <a
+                            class="flex items-center gap-1 text-sm px-5 py-2 hover:bg-gray"
+                            href="#"
+                          >
+                            <span class="inline-block w-6 h-6"
+                              ><TrashIcon
+                            /></span>
+                            <p>刪除</p>
+                          </a>
+                        </li>
+                        <DeletePerPlaceModal />
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+                <!-- hover:relative feature -->
+                <div class="more lg:hidden">
+                  <div
+                    class="h-10 flex justify-between items-center border-t border-white"
+                  >
+                    <ul class="flex gap-4 p-3">
+                      <li
+                        class="flex items-center text-gray-500 gap-1 hover:cursor-pointer"
+                        @click="edit_place.showModal()"
+                      >
+                        <span class="w-3 h-3"><PencilIcon /></span>
+                        <p class="text-xs">編輯</p>
+                      </li>
+                      <EditPlaceModal />
+                      <li
+                        class="flex items-center text-gray-500 gap-1 hover:cursor-pointer"
+                      >
+                        <span class="w-3 h-3"><MagnifyingGlassIcon /></span>
+                        <p class="text-xs">周邊</p>
+                      </li>
+                      <li
+                        class="flex items-center text-gray-500 gap-1 hover:cursor-pointer"
+                        @click="place_note_1.showModal()"
+                      >
+                        <span class="w-3 h-3"><BookmarkIcon /></span>
+                        <p class="text-xs">筆記</p>
+                      </li>
+                      <!-- place & transportation -->
+                      <!-- place note -->
+                      <dialog id="place_note_1" class="modal">
+                        <div
+                          class="modal-box min-w-full md:min-w-[480px] min-h-screen md:min-h-[90%]"
+                        >
+                          <form method="dialog">
+                            <button
+                              class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+                            >
+                              ✕
+                            </button>
+                          </form>
+                          <h2
+                            class="text-2xl font-medium text-center pt-6 mb-4"
+                          >
+                            景點筆記
+                          </h2>
+                          <textarea
+                            class="w-full h-[500px] textarea textarea-lg focus:border-0 focus:outline-none"
+                            placeholder="還沒有寫筆記哦"
+                          ></textarea>
+                          <div
+                            class="w-full flex gap-3 h-20 px-6 py-4 bg-white border-t border-gray fixed bottom-0 right-0"
+                          >
+                            <button
+                              class="w-full h-12 px-5 py-3 border border-primary-600 text-primary-600 text-center rounded-3xl font-medium hover:bg-primary-100"
+                            >
+                              取消
+                            </button>
+                            <button
+                              class="w-full h-12 px-5 py-3 bg-primary-600 hover:bg-primary-700 text-white text-center rounded-3xl font-medium"
+                            >
+                              儲存
+                            </button>
+                          </div>
+                        </div>
+                        <form method="dialog" class="modal-backdrop">
+                          <button
+                            class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+                          >
+                            ✕
+                          </button>
+                          <button>close</button>
+                        </form>
+                      </dialog>
+                    </ul>
+                    <span
+                      class="w-10 h-10 text-gray-500 p-3 border-l border-white hover:cursor-pointer"
+                      ><MapPinIcon
+                    /></span>
+                  </div>
                 </div>
               </div>
             </div>
-            <!-- hover:relative feature -->
-            <div class="more lg:hidden">
-              <div class="h-10 flex justify-between items-center border-t border-white">
-                <ul class="flex gap-4 p-3">
-                  <li class="flex items-center text-gray-500 gap-1 hover:cursor-pointer" @click="edit_place.showModal()">
-                    <span class="w-3 h-3"><PencilIcon/></span>
-                    <p class="text-xs">編輯</p>
-                  </li>
-                  <EditPlaceModal />
-                  <li class="flex items-center text-gray-500 gap-1 hover:cursor-pointer">
-                    <span class="w-3 h-3"><MagnifyingGlassIcon/></span>
-                    <p class="text-xs">周邊</p>
-                  </li>
-                  <li class="flex items-center text-gray-500 gap-1 hover:cursor-pointer" @click="place_note_1.showModal()">
-                    <span class="w-3 h-3"><BookmarkIcon/></span>
-                    <p class="text-xs">筆記</p>
-                  </li>
-              <!-- place & transportation -->
-                  <!-- place note -->
-                  <dialog id="place_note_1" class="modal">
-                    <div class="modal-box min-w-full md:min-w-[480px] min-h-screen md:min-h-[90%]">
-                      <form method="dialog">
-                        <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-                      </form>
-                      <h2 class="text-2xl font-medium text-center pt-6 mb-4">景點筆記</h2>
-                      <textarea class="w-full h-[500px] textarea textarea-lg focus:border-0 focus:outline-none" placeholder="還沒有寫筆記哦"></textarea>
-                      <div class="w-full flex gap-3 h-20 px-6 py-4 bg-white border-t border-gray fixed bottom-0 right-0">
-                        <button class="w-full h-12 px-5 py-3 border border-primary-600 text-primary-600 text-center rounded-3xl font-medium hover:bg-primary-100">
-                          取消
-                        </button>
-                        <button class="w-full h-12 px-5 py-3 bg-primary-600 hover:bg-primary-700 text-white text-center rounded-3xl font-medium">
-                          儲存
-                        </button>
-                      </div>
-                    </div>
-                    <form method="dialog" class="modal-backdrop">
-                      <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
-                      <button>close</button>
-                    </form>
-                  </dialog> 
-                </ul>
-                <span class="w-10 h-10 text-gray-500 p-3 border-l border-white hover:cursor-pointer"><MapPinIcon/></span>
-              </div>
-            </div>
-            </div>
+            <p
+              v-if="element !== place[place.length - 1]"
+              class="w-full ml-3 py-4 ps-3 border-l border-dashed border-gray hover:cursor-pointer"
+              @click="transportationToggle"
+            >
+              {{ `自訂交通 ${element.transhour} 分` }}
+            </p>
           </div>
-          <p v-if="element !== place[place.length - 1]" class="w-full ml-3 py-4 ps-3 border-l border-dashed border-gray hover:cursor-pointer" @click="transportationToggle">{{ `自訂交通 ${element.transhour} 分` }}</p>
-        </div>
         </template>
       </draggable>
     </div>
+  </div>
 </template>
 
 <style>
-.date:hover > .dropdown{
+.date:hover > .dropdown {
   display: inline;
 }
-.place:hover > .more{
-    display: block;
-  }
-.w-cal{
+.place:hover > .more {
+  display: block;
+}
+.w-cal {
   width: calc(100% - 108px);
 }
 </style>

--- a/src/components/ScheduleSideBar.vue
+++ b/src/components/ScheduleSideBar.vue
@@ -1,9 +1,9 @@
 <script setup>
-import { ref, provide } from 'vue'
-import { GlobeAsiaAustraliaIcon } from '@heroicons/vue/24/outline'
-import SchedulesList from './SchedulesList.vue'
-import ScheduleDetail from '@/components/ScheduleDetail.vue'
-import TransportationWay from './TransportationWay.vue'
+import { ref, provide } from "vue"
+import { GlobeAsiaAustraliaIcon } from "@heroicons/vue/24/outline"
+import SchedulesList from "./SchedulesList.vue"
+import ScheduleDetail from "@/components/ScheduleDetail.vue"
+import TransportationWay from "./TransportationWay.vue"
 
 const scheduleToggleShow = ref(true)
 
@@ -17,19 +17,24 @@ const listToggle = () => {
   scheduleToggleShow.value = !scheduleToggleShow.value
 }
 // 給 SchedulesList 關閉自己
-provide('listToggle', listToggle)
+provide("listToggle", listToggle)
 
 // schedule detail 開關
 const detailOpen = ref(false)
-const detailToggle = () => {
-  detailOpen.value = !detailOpen.value
+const scheduleId = ref("")
+const detailToggle = async (id) => {
+  scheduleId.value = id
+  listOpen.value = !listOpen.value
+  detailOpen.value = await !detailOpen.value
+  listOpen.value = !listOpen.value
 }
 // 給 SchedulesList 進入 ScheduleDetail
 // 給 ScheduleDetail 關閉自己
-provide('detailToggle', detailToggle)
+provide("detailToggle", detailToggle)
+provide("scheduleId", scheduleId)
 
 // 給 ScheduleDetail 關閉全部
-provide('listAndDetailToggle', () => {
+provide("listAndDetailToggle", () => {
   listOpen.value = !listOpen.value
   scheduleToggleShow.value = !scheduleToggleShow.value
   detailOpen.value = !detailOpen.value
@@ -43,7 +48,7 @@ const transportationToggle = () => {
 
 // 給 ScheduleDetail 進入 TransportationWay
 // 給 TransportationWay 關閉自己
-provide('transportationToggle', transportationToggle)
+provide("transportationToggle", transportationToggle)
 </script>
 
 <template>

--- a/src/components/SchedulesList.vue
+++ b/src/components/SchedulesList.vue
@@ -18,11 +18,9 @@ const LoginStore = LoginModalStore()
 const listToggle = inject("listToggle")
 const detailToggle = inject("detailToggle")
 const API_URL = process.env.VITE_HOST_URL
-
 const isLogin = ref(false)
 const token = localStorage.getItem("token")
 
-// 讀取行程資料
 const hasSchedules = ref(false)
 const checkedSchedule = ref("mine")
 const schedules = ref([])
@@ -81,12 +79,13 @@ const sortedSchedules = computed(() => {
   })
 })
 
+// 複製行程
 const scheduleName = ref("")
+const scheduleNote = ref("")
 const coverImage = ref("")
 const startDate = ref("")
 const endDate = ref("")
 const transportationWay = ref("")
-
 const scheduleDuplicate = async (id) => {
   const config = {
     headers: {
@@ -96,6 +95,7 @@ const scheduleDuplicate = async (id) => {
   try {
     const response = await axios.get(`${API_URL}/schedules/${id}`, config)
     scheduleName.value = response.data.title
+    scheduleNote.value = response.data.schedule_note
     coverImage.value = response.data.image_url
     startDate.value = response.data.start_date.split("T")[0]
     endDate.value = response.data.end_date.split("T")[0]
@@ -105,7 +105,6 @@ const scheduleDuplicate = async (id) => {
     console.error(error.message)
   }
 }
-
 const copySchedule = async () => {
   const config = {
     headers: {
@@ -115,6 +114,7 @@ const copySchedule = async () => {
   const ScheduleData = {
     title: scheduleName.value,
     image_url: coverImage.value,
+    schedule_note: scheduleNote.value,
     start_date: startDate.value,
     end_date: endDate.value,
     transportation_way: transportationWay.value,
@@ -126,6 +126,8 @@ const copySchedule = async () => {
     console.error(err.message)
   }
 }
+
+const showNewSchedule = inject("showNewSchedule")
 
 onMounted(async () => {
   if (token) {
@@ -206,7 +208,7 @@ onMounted(async () => {
                   class="card card-compact bg-base-100 sm:w-full md:w-[30%] lg:w-full h-[176px] lg:h-auto border-gray border mb-4 relative hover:cursor-pointer"
                 >
                   <figure
-                    @click="detailToggle"
+                    @click="detailToggle(item.id)"
                     class="w-full h-[150px] overflow-hidden"
                   >
                     <img
@@ -383,7 +385,7 @@ onMounted(async () => {
           >
             <button
               class="w-full h-12 px-5 py-3 bg-primary-600 text-white text-center text-base rounded-3xl hover:bg-primary-700"
-              onclick="NewSchedule.showModal()"
+              onclick="newSchedule.showModal()"
             >
               建立新行程
             </button>

--- a/src/views/MemberView.vue
+++ b/src/views/MemberView.vue
@@ -56,6 +56,8 @@ const getUser = async () => {
     }
   } catch (error) {
     console.error(error.message)
+    localStorage.removeItem("token")
+    localStorage.removeItem("userId")
     router.push("/")
   }
 }


### PR DESCRIPTION
- 進到單一行程可以抓到該行程資訊
<img width="346" alt="image" src="https://github.com/user-attachments/assets/b08658d8-a990-4230-80d4-87b699a88022" />
>>
<img width="343" alt="image" src="https://github.com/user-attachments/assets/5d9c377f-1eca-4b55-9536-4a01ce166d1b" />

- 點擊行程名稱右側「鉛筆」可以編輯行程
目前除了「封面照片」外都可以編輯，「封面照片」編輯待處理。
<img width="700" alt="image" src="https://github.com/user-attachments/assets/9f4e73dd-790e-4be8-915d-472718bdeaf7" />

- 行程筆記，分為沒有新增筆記的提示，以及新增筆記後的說明
<img width="700" alt="image" src="https://github.com/user-attachments/assets/cc52c4c8-a34a-4723-85a0-4ba4f7fc1b62" />
<img width="700" alt="image" src="https://github.com/user-attachments/assets/a9a3a18a-628d-4adc-83cb-00cb180f1f77" />

