### PR TITLE
hotfix: summary 監聽 scheduleData 更新時間改為每三秒一次

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@iconoir/vue": "^7.10.1",
         "axios": "^1.7.9",
         "jspdf": "^2.5.2",
+        "lodash": "^4.17.21",
         "pinia": "^2.2.6",
         "pinia-plugin-persistedstate": "^4.2.0",
         "qrcode": "^1.5.4",
@@ -3147,6 +3148,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite --host 0.0.0.0",
     "build": "vite build",
     "preview": "vite preview",
-    "start":"node --max-old-space-size=4096 server.js"
+    "start": "node --max-old-space-size=4096 server.js"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
@@ -16,6 +16,7 @@
     "@iconoir/vue": "^7.10.1",
     "axios": "^1.7.9",
     "jspdf": "^2.5.2",
+    "lodash": "^4.17.21",
     "pinia": "^2.2.6",
     "pinia-plugin-persistedstate": "^4.2.0",
     "qrcode": "^1.5.4",

--- a/src/components/ScheduleSummaryModal.vue
+++ b/src/components/ScheduleSummaryModal.vue
@@ -5,6 +5,7 @@ import "../assets/fonts/NotoSansTC.js"
 import axios from "axios"
 import EmailScheduleSummary from "./EmailScheduleSummary.vue"
 import { DocumentArrowDownIcon } from "@heroicons/vue/24/outline"
+import { debounce } from 'lodash';
 
 const API_URL = process.env.VITE_HOST_URL
 const token = localStorage.getItem("token")
@@ -14,7 +15,7 @@ const scheduleName = ref("")
 const schedulePlaces = ref("")
 const groupedData = ref("")
 
-const getSchedule = async (id) => {
+const getSchedule = debounce(async (id) => {
   const config = {
     headers: {
       Authorization: token,
@@ -74,7 +75,7 @@ const getSchedule = async (id) => {
   } catch (error) {
     console.error(error)
   }
-}
+}, 3000)
 
 const scheduleSummary = ref(null)
 const generatePDF = () => {
@@ -93,9 +94,9 @@ const generatePDF = () => {
 }
 
 const scheduleSummaryText = ref("")
-watch(schedulesData, () => {
-  getSchedule(scheduleId.value)
-  if (scheduleSummary.value) {
+watch(schedulesData, (newVal, oldVal) => {
+  if (newVal !== oldVal && scheduleSummary.value) {
+    getSchedule(scheduleId.value)
     scheduleSummaryText.value = scheduleSummary.value.innerText.split("\n")
   }
 })


### PR DESCRIPTION
因為行程摘要需要監聽行程是否有更新，同步更新行程摘要的內容。
原先的監聽有點死胡同會瘋狂打 API 更新，現改為每三秒更新一次。